### PR TITLE
19 download zip failure

### DIFF
--- a/wilma-message-search/modules/wilma-message-search-webapp/src/main/java/com/epam/wilma/message/search/web/support/FileZipper.java
+++ b/wilma-message-search/modules/wilma-message-search-webapp/src/main/java/com/epam/wilma/message/search/web/support/FileZipper.java
@@ -66,6 +66,7 @@ public class FileZipper {
                     String fileName = getFileName(filePath);
                     InputStream file = new FileInputStream(filePath);
                     addFileToZipStream(zipStream, fileName, file);
+                    file.close();
                 } catch (IOException ex) {
                     logger.warn("Reading or zipping is failed with file: " + filePath, ex);
                 }


### PR DESCRIPTION
Ticket:
https://github.com/epam/Wilma/issues/19

Description:
When I downloaded the result zip of a search, that archive file was broken. I couldn't open that file.
